### PR TITLE
Rivet routine fix

### DIFF
--- a/RivetPlugins/Higgs2GGFiducialAndDifferential.cc
+++ b/RivetPlugins/Higgs2GGFiducialAndDifferential.cc
@@ -10,8 +10,8 @@ namespace Rivet
 
         //---Photons
         IdentifiedFinalState fs_photons;
+        fs_photons.acceptId(PID::PHOTON);
         declare(fs_photons, "FS_PHOTONS");
-        declare(PromptFinalState(fs), "FS_PROMPT_PHOTONS");
 
         //---Jets
         FastJets fs_jets(fs, FastJets::ANTIKT, 0.4);
@@ -33,7 +33,7 @@ namespace Rivet
 
     void Higgs2GGFiducialAndDifferential::analyze(const Event& event)
     {               
-        auto photons = apply<PromptFinalState>(event, "FS_PROMPT_PHOTONS").particles();       
+        auto photons = apply<IdentifiedFinalState>(event, "FS_PHOTONS").particlesByPt();       
 
         if (photons.size() < 2) 
             vetoEvent;       

--- a/RivetPlugins/Higgs2GGFiducialAndDifferential.h
+++ b/RivetPlugins/Higgs2GGFiducialAndDifferential.h
@@ -5,7 +5,6 @@
 
 #include "Rivet/Tools/RivetYODA.hh"
 #include "Rivet/Projections/FinalState.hh" 
-#include "Rivet/Projections/PromptFinalState.hh" 
 #include "Rivet/Projections/IdentifiedFinalState.hh"
 #include "Rivet/Projections/FastJets.hh"
 


### PR DESCRIPTION
Changes:
1) Routine considers all photons in the event instead of only the prompt particles
2) Only photons are selected
3) Photons ordered by pt